### PR TITLE
Fix: move typing_extensions import under TYPE_CHECKING

### DIFF
--- a/ydb_dbapi/cursors.py
+++ b/ydb_dbapi/cursors.py
@@ -13,7 +13,6 @@ from typing import Callable
 from typing import Union
 
 import ydb
-from typing_extensions import Self
 
 from .errors import DatabaseError
 from .errors import InterfaceError
@@ -24,6 +23,8 @@ from .utils import handle_ydb_errors
 from .utils import maybe_get_current_trace_id
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .connections import AsyncConnection
     from .connections import Connection
 


### PR DESCRIPTION
## Summary

Fixes #37.

`cursors.py` imported `Self` from `typing_extensions` at module level, but `typing-extensions` was not declared as an explicit dependency. This broke with Poetry 2.x on Python 3.12+, where the package is not installed (its marker is computed as `python_version < "3.11"` from transitive deps).

**Fix:** since `from __future__ import annotations` is already present, `Self` is only used in type annotations that are never evaluated at runtime. Moving the import under `if TYPE_CHECKING:` eliminates the runtime dependency entirely — no changes to `pyproject.toml` needed.

## Changes

- `ydb_dbapi/cursors.py`: moved `from typing_extensions import Self` under `if TYPE_CHECKING:`

## Test plan

- [x] `python -c "import ydb_dbapi"` succeeds on Python 3.12+ without `typing-extensions` installed
- [x] `ruff check` passes
- [x] `mypy` passes