### PR TITLE
Release session in close() even if rollback fails

### DIFF
--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -77,25 +77,31 @@ class BaseDBApiTestSuit:
         assert acquired_session is not None
 
         released = []
-        original_release = connection._session_pool.release
+        session_pool = connection._session_pool
+        tx_context = connection._tx_context
+        original_release = session_pool.release
+        original_rollback = tx_context.rollback
 
         def release(session: ydb.QuerySession) -> any:
             released.append(session)
             return original_release(session)
 
-        connection._session_pool.release = release
-
         def failing_rollback(*args: any, **kwargs: any) -> None:
             raise ydb.issues.BadSession("session is invalidated")
 
-        connection._tx_context.rollback = failing_rollback
+        session_pool.release = release
+        tx_context.rollback = failing_rollback
 
-        with pytest.raises(dbapi.Error):
-            maybe_await(connection.close())
+        try:
+            with pytest.raises(dbapi.Error):
+                maybe_await(connection.close())
 
-        assert released == [acquired_session]
-        assert connection._session is None
-        assert connection._tx_context is None
+            assert released == [acquired_session]
+            assert connection._session is None
+            assert connection._tx_context is None
+        finally:
+            session_pool.release = original_release
+            tx_context.rollback = original_rollback
 
     def _test_connection(self, connection: dbapi.Connection) -> None:
         maybe_await(connection.commit())

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -66,6 +66,37 @@ class BaseDBApiTestSuit:
             maybe_await(connection.rollback())
 
 
+    def _test_close_releases_session_after_rollback_error(
+        self,
+        connection: dbapi.Connection,
+    ) -> None:
+        connection.set_isolation_level(dbapi.IsolationLevel.SERIALIZABLE)
+        maybe_await(connection.begin())
+
+        acquired_session = connection._session
+        assert acquired_session is not None
+
+        released = []
+        original_release = connection._session_pool.release
+
+        def release(session: ydb.QuerySession) -> any:
+            released.append(session)
+            return original_release(session)
+
+        connection._session_pool.release = release
+
+        def failing_rollback(*args: any, **kwargs: any) -> None:
+            raise ydb.issues.BadSession("session is invalidated")
+
+        connection._tx_context.rollback = failing_rollback
+
+        with pytest.raises(dbapi.Error):
+            maybe_await(connection.close())
+
+        assert released == [acquired_session]
+        assert connection._session is None
+        assert connection._tx_context is None
+
     def _test_connection(self, connection: dbapi.Connection) -> None:
         maybe_await(connection.commit())
         maybe_await(connection.rollback())
@@ -466,6 +497,11 @@ class TestConnection(BaseDBApiTestSuit):
             connection, isolation_level
         )
 
+    def test_close_releases_session_after_rollback_error(
+        self, connection: dbapi.Connection
+    ) -> None:
+        self._test_close_releases_session_after_rollback_error(connection)
+
     def test_connection(self, connection: dbapi.Connection) -> None:
         self._test_connection(connection)
 
@@ -578,6 +614,14 @@ class TestAsyncConnection(BaseDBApiTestSuit):
             self._test_commit_rollback_after_begin,
             connection,
             isolation_level
+        )
+
+    @pytest.mark.asyncio
+    async def test_close_releases_session_after_rollback_error(
+        self, connection: dbapi.AsyncConnection
+    ) -> None:
+        await greenlet_spawn(
+            self._test_close_releases_session_after_rollback_error, connection
         )
 
     @pytest.mark.asyncio

--- a/ydb_dbapi/connections.py
+++ b/ydb_dbapi/connections.py
@@ -291,14 +291,18 @@ class Connection(BaseConnection):
 
     @handle_ydb_errors
     def close(self) -> None:
-        self.rollback()
+        try:
+            self.rollback()
+        finally:
+            self._tx_context = None
 
-        if self._session:
-            self._session_pool.release(self._session)
+            if self._session:
+                self._session_pool.release(self._session)
+                self._session = None
 
-        if not self._shared_session_pool:
-            self._session_pool.stop()
-            self._driver.stop()
+            if not self._shared_session_pool:
+                self._session_pool.stop()
+                self._driver.stop()
 
     @handle_ydb_errors
     def describe(self, table_path: str) -> ydb.TableSchemeEntry:
@@ -489,14 +493,18 @@ class AsyncConnection(BaseConnection):
 
     @handle_ydb_errors
     async def close(self) -> None:
-        await self.rollback()
+        try:
+            await self.rollback()
+        finally:
+            self._tx_context = None
 
-        if self._session:
-            await self._session_pool.release(self._session)
+            if self._session:
+                await self._session_pool.release(self._session)
+                self._session = None
 
-        if not self._shared_session_pool:
-            await self._session_pool.stop()
-            await self._driver.stop()
+            if not self._shared_session_pool:
+                await self._session_pool.stop()
+                await self._driver.stop()
 
     @handle_ydb_errors
     async def describe(self, table_path: str) -> ydb.TableSchemeEntry:


### PR DESCRIPTION
Fixes #42

`close()` called `rollback()` first and released the session only afterwards. If `rollback()` raised — the expected outcome when the session was invalidated mid-request — the release was skipped, the session was abandoned and its pool slot was lost permanently.

Session release, `_tx_context` reset and owned pool/driver shutdown now happen in a `finally`, in both `Connection` and `AsyncConnection`. The rollback error is still propagated.

Test: `begin()`, force `tx_context.rollback` to raise `BadSession`, assert `close()` raises but still releases the session back to the pool.